### PR TITLE
Keyboard shortcut fixed

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -616,10 +616,10 @@
        <item>
         <widget class="QCheckBox" name="hideTrayIcon">
          <property name="toolTip">
-          <string>&amp;Hide the icon from the system tray.</string>
+          <string>Hide the icon from the system tray.</string>
          </property>
          <property name="text">
-          <string>Hide tray icon</string>
+          <string>&amp;Hide tray icon</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
The keyboard shortcut should be in the text property instead of the toolTip property.