### PR TITLE
fix: remove hard coded Version check

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2184,14 +2184,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
         pfrom->nStartingHeight = nStartingHeight;
 
-        // disconnect nodes that arent at least 16.x series
-        if (pfrom->cleanSubVer.find("0.16") == std::string::npos) {
-            LogPrintf("connected to legacy version (%s), disconnecting from node %s\n", pfrom->cleanSubVer, pfrom->GetId());
-            Misbehaving(pfrom->GetId(), 0);
-            pfrom->fDisconnect = true;
-            return true;
-        }
-
         // set nodes not relaying blocks and tx and not serving (parts) of the historical blockchain as "clients"
         pfrom->fClient = (!(nServices & NODE_NETWORK) && !(nServices & NODE_NETWORK_LIMITED));
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

GoByte 0.16.x version has a hardcoded version check inside /src/net_processing.cpp (2186 - 2193) introduced by "barrystyle" 4 years ago. This hardcoded version check makes it impossible to upgrade the network to 0.17.x and beyond.

## What was done?

Removed the following code from net_processing.cpp

        // disconnect nodes that arent at least 16.x series
        if (pfrom->cleanSubVer.find("0.16") == std::string::npos) {
            LogPrintf("connected to legacy version (%s), disconnecting from node %s\n", pfrom->cleanSubVer, pfrom->GetId());
            Misbehaving(pfrom->GetId(), 0);
            pfrom->fDisconnect = true;
            return true;
        }


## How Has This Been Tested?

The change can be tested by compiling the same source code with versions changed in configure.ac
Same code compiled with version 0.15.x or 0.17.x will not connect to the current 0.16.x nodes, even if the consensus and the entire code are the same. After removing the hardcoded version check, the node accepts connections from any wallet version as long as they satisfy the >= MIN_PEER_PROTO_VERSION check.

    define(_CLIENT_VERSION_MAJOR, 0)
    define(_CLIENT_VERSION_MINOR, 16)
    define(_CLIENT_VERSION_REVISION, 2)
    define(_CLIENT_VERSION_BUILD, 2)

## Breaking Changes
 
None.

## Checklist:
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_