### PR TITLE
chore: update dependency download mirrors to reliable sources

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,7 +1,7 @@
 package=boost
-$(package)_version=1_64_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
-$(package)_file_name=$(package)_$($(package)_version).tar.bz2
+$(package)_version=1.64.0
+$(package)_download_path=https://archives.boost.io/release/$($(package)_version)/source/
+$(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
 
 define $(package)_set_vars

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,6 +1,6 @@
 package=expat
 $(package)_version=2.2.1
-$(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$($(package)_version))/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=1868cadae4c82a018e361e2b2091de103cd820aaacb0d6cfa49bd2cd83978885
 

--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -1,6 +1,6 @@
 package=gmp
 $(package)_version=6.1.2
-$(package)_download_path=https://gmplib.org/download/gmp
+$(package)_download_path=https://ftp.gnu.org/gnu/gmp
 $(package)_file_name=gmp-$($(package)_version).tar.bz2
 $(package)_sha256_hash=5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2
 

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared -without-tools --disable-sdltest
+$(package)_config_opts=--disable-shared --without-tools --disable-sdltest
 $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -1,6 +1,6 @@
 package=zlib
 $(package)_version=1.2.11
-$(package)_download_path=http://www.zlib.net
+$(package)_download_path=https://www.zlib.net/fossils/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Update download URLs for boost, expat, gmp, qrencode, and zlib packages to use more reliable and maintained sources, replacing deprecated or unstable mirrors (bintray, sourceforge, etc.) with GitHub releases, GNU FTP, and official archives.

## What was done?

Mirror links updated for the following packages:

- **boost**: Changed from `https://dl.bintray.com/boostorg/release/1.64.0/source/` to `https://archives.boost.io/release/1.64.0/source/`
  - Normalized version format from `1_64_0` to `1.64.0`
  - Updated file name to use version substitution

- **expat**: Changed from `https://downloads.sourceforge.net/project/expat/expat/2.2.1` to `https://github.com/libexpat/libexpat/releases/download/R_2_2_1/`

- **gmp**: Changed from `https://gmplib.org/download/gmp` to `https://ftp.gnu.org/gnu/gmp`

- **zlib**: Changed from `http://www.zlib.net` to `https://www.zlib.net/fossils/` (HTTPS and specific version archive)

## How Has This Been Tested?

The changes were tested by running the following commands inside the `/depends/` folder:

- __Download for all platforms (macOS, Linux, Windows):__

  ```bash
  make download
  ```

- __Verify existing downloads:__

  ```bash
  make check-sources
  ```

 __Test Results:__
  All packages downloaded successfully and SHA256 checksums verified:
  - ✅ boost 1.64.0 - Downloaded and verified
  - ✅ expat 2.2.1 - Downloaded and verified
  - ✅ gmp 6.1.2 - Downloaded and verified
  - ✅ zlib 1.2.11 - Downloaded and verified
  - ✅ All other dependencies (openssl, libevent, zeromq, protobuf, qt, bdb, miniupnpc, etc.)


## Breaking Changes

None - All SHA256 hashes remain valid as the files themselves have not changed, only the download sources.

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated download sources and archive naming/version formatting for several third‑party libraries (Boost, Expat, GMP, Zlib) to use updated upstream locations and consistent version syntax.
* **Bug Fixes**
  * Corrected QRencode configure options to remove a malformed option and ensure proper configure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->