### PR TITLE
fix: Re-enable BIP34 height check and correct BIP34Height value

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -317,8 +317,8 @@ public:
         consensus.nGovernanceMinQuorum = 10;
         consensus.nGovernanceFilterElements = 20000;
         consensus.nMasternodeMinimumConfirmations = 15;
-        consensus.BIP34Height = 1;
-        consensus.BIP34Hash = uint256S("0x00000c8a1ff01bae3f3875c81cb14115429af5744643b34b4ad1cbb7d2d59ca2");
+        consensus.BIP34Height = 17;
+        consensus.BIP34Hash = uint256S("0x0000003f796a7213b048b71f86e692206880e9638dce198955fd5f4e16dc8a2d");
         consensus.BIP65Height = 619382; // 00000000000076d8fcea02ec0963de4abfd01e771fec0863f960c2c64fe6f357
         consensus.BIP66Height = 245817; // 00000000000b1fa2dfa312863570e13fae9ca7b5566cb27e55422620b469aefa
         consensus.DIP0001Height = 124992;
@@ -541,7 +541,7 @@ public:
         consensus.nPowTargetSpacing = 2.5 * 60; // GoByte: 150 seconds
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
-        consensus.nPowDGWHeight = 650; // TODO: make sure to drop all spork6 related code on next testnet reset
+        consensus.nPowDGWHeight = 650;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3505,14 +3505,14 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
     // Enforce rule that the coinbase starts with serialized block height
     // After DIP3/DIP4 activation, we don't enforce the height in the input script anymore.
     // The CbTx special transaction payload will then contain the height, which is checked in CheckCbTx
-//  if (nHeight >= consensusParams.BIP34Height && !fDIP0003Active_context)
-//  {
-//      CScript expect = CScript() << nHeight;
-//      if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
-//          !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {
-//          return state.DoS(100, false, REJECT_INVALID, "bad-cb-height", false, "block height mismatch in coinbase");
-//      }
-//  }
+  if (nHeight >= consensusParams.BIP34Height && !fDIP0003Active_context)
+  {
+      CScript expect = CScript() << nHeight;
+      if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
+          !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {
+          return state.DoS(100, false, REJECT_INVALID, "bad-cb-height", false, "block height mismatch in coinbase");
+      }
+  }
 
     if (fDIP0003Active_context) {
         if (block.vtx[0]->nType != TRANSACTION_COINBASE) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

This PR reduces technical debt by re-enabling BIP34 coinbase height validation to align with our upstream codebase (Dash).
This validation is enforced before DIP0003 activation and becomes irrelevant after block 790,000.


## Motivation

GoByte forked from Dash, which uses this BIP34 validation check without commenting it out. Re-enabling this code improves code maintainability and reduces divergence from upstream. The BIP34Height value of 17 correctly reflects the first block that implements BIP34 with proper 2-byte height encoding.


## What was done?

1. Updated `BIP34Height` from 1 to 17 in `src/chainparams.cpp`
2. Re-enabled the BIP34 coinbase height validation check in `src/validation.cpp`:

```
-//  if (nHeight >= consensusParams.BIP34Height && !fDIP0003Active_context)
-//  {
-//      CScript expect = CScript() << nHeight;
-//      if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
-//          !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {
-//          return state.DoS(100, false, REJECT_INVALID, "bad-cb-height", false, "block height mismatch in coinbase");
-//      }
-//  }
+  if (nHeight >= consensusParams.BIP34Height && !fDIP0003Active_context)
+  {
+      CScript expect = CScript() << nHeight;
+      if (block.vtx[0]->vin[0].scriptSig.size() < expect.size() ||
+          !std::equal(expect.begin(), expect.end(), block.vtx[0]->vin[0].scriptSig.begin())) {
+          return state.DoS(100, false, REJECT_INVALID, "bad-cb-height", false, "block height mismatch in coinbase");
+      }
+  }
```

3. Removed outdated TODO comment: `// TODO: make sure to drop all spork6 related code on next testnet reset`

## How Has This Been Tested?

- Tested full wallet sync with empty `.gobytecore` folder using various `BIP34Height` values
- Verified that sync fails when `BIP34Height` is set below block 17 (due to BIP34 coinbase height validation)
- Confirmed successful sync with `BIP34Height = 17` or above

## Breaking Changes

None. This change only affects pre-DIP0003 blocks (before block 790,000).

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

## Related Documentation

- [BIP34: Block v2, Height in Coinbase](https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Re-enabled coinbase block-height validation to reject blocks with mismatched coinbase height, strengthening block validation and network consensus.

* **Chores**
  * Adjusted mainnet consensus activation timing for a specific validation rule to ensure consistent enforcement across nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->