### PR TITLE
lint: standardize include guard naming to BITCOIN_* pattern

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -26,4 +26,4 @@ static const CAmount CENT = 1000000;
 static const CAmount MAX_MONEY = 31800000 * COIN;
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
-#endif //  BITCOIN_AMOUNT_H
+#endif // BITCOIN_AMOUNT_H

--- a/src/ctpl.h
+++ b/src/ctpl.h
@@ -18,8 +18,8 @@
  *********************************************************/
 
 
-#ifndef __ctpl_thread_pool_H__
-#define __ctpl_thread_pool_H__
+#ifndef BITCOIN_CTPL_H
+#define BITCOIN_CTPL_H
 
 #include <functional>
 #include <thread>
@@ -236,5 +236,5 @@ namespace ctpl {
 
 }
 
-#endif // __ctpl_thread_pool_H__
+#endif // BITCOIN_CTPL_H
 

--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -32,4 +32,4 @@ void InterruptREST();
  */
 void StopREST();
 
-#endif
+#endif // BITCOIN_HTTPRPC_H

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -56,4 +56,4 @@ public:
     }
 };
 
-#endif //  BITCOIN_POLICY_FEERATE_H
+#endif // BITCOIN_POLICY_FEERATE_H

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -33,4 +33,4 @@ UniValue mempoolToJSON(bool fVerbose = false);
 /** Block header to JSON */
 UniValue blockheaderToJSON(const CBlockIndex* blockindex);
 
-#endif
+#endif // BITCOIN_RPC_BLOCKCHAIN_H

--- a/src/rpc/mining.h
+++ b/src/rpc/mining.h
@@ -15,4 +15,4 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
 /** Check bounds on a command line confirm target */
 unsigned int ParseConfirmTarget(const UniValue& value);
 
-#endif
+#endif // BITCOIN_RPC_MINING_H

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -124,4 +124,4 @@ public:
     size_t CallbacksPending();
 };
 
-#endif
+#endif // BITCOIN_SCHEDULER_H

--- a/src/span.h
+++ b/src/span.h
@@ -37,4 +37,4 @@ public:
 template<typename V>
 constexpr Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type> MakeSpan(V& v) { return Span<typename std::remove_pointer<decltype(std::declval<V>().data())>::type>(v.data(), v.size()); }
 
-#endif
+#endif // BITCOIN_SPAN_H

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -180,4 +180,4 @@ private:
 };
 
 
-#endif // BITCOIN_TEST_BIGNUM_H
+#endif // BITCOIN_TEST_SCRIPTNUM10_H

--- a/src/test/test_gobyte.h
+++ b/src/test/test_gobyte.h
@@ -166,4 +166,4 @@ struct TestMemPoolEntryHelper {
 
 CBlock getBlock13b8a();
 
-#endif
+#endif // BITCOIN_TEST_TEST_GOBYTE_H

--- a/src/threadinterrupt.h
+++ b/src/threadinterrupt.h
@@ -31,4 +31,4 @@ private:
     std::atomic<bool> flag;
 };
 
-#endif //BITCOIN_THREADINTERRUPT_H
+#endif // BITCOIN_THREADINTERRUPT_H

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -17,4 +17,4 @@ void StartTorControl();
 void InterruptTorControl();
 void StopTorControl();
 
-#endif /* BITCOIN_TORCONTROL_H */
+#endif // BITCOIN_TORCONTROL_H

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef __UNIVALUE_H__
-#define __UNIVALUE_H__
+#ifndef BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H
+#define BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H
 
 #include <stdint.h>
 #include <string.h>
@@ -303,4 +303,4 @@ extern const UniValue NullUniValue;
 
 const UniValue& find_value( const UniValue& obj, const std::string& name);
 
-#endif // __UNIVALUE_H__
+#endif // BITCOIN_UNIVALUE_INCLUDE_UNIVALUE_H

--- a/src/univalue/lib/univalue_escapes.h
+++ b/src/univalue/lib/univalue_escapes.h
@@ -1,6 +1,6 @@
 // Automatically generated file. Do not modify.
-#ifndef BITCOIN_UNIVALUE_UNIVALUE_ESCAPES_H
-#define BITCOIN_UNIVALUE_UNIVALUE_ESCAPES_H
+#ifndef BITCOIN_UNIVALUE_LIB_UNIVALUE_ESCAPES_H
+#define BITCOIN_UNIVALUE_LIB_UNIVALUE_ESCAPES_H
 static const char *escapes[256] = {
 	"\\u0000",
 	"\\u0001",
@@ -259,4 +259,4 @@ static const char *escapes[256] = {
 	NULL,
 	NULL,
 };
-#endif // BITCOIN_UNIVALUE_UNIVALUE_ESCAPES_H
+#endif // BITCOIN_UNIVALUE_LIB_UNIVALUE_ESCAPES_H

--- a/src/univalue/lib/univalue_utffilter.h
+++ b/src/univalue/lib/univalue_utffilter.h
@@ -1,8 +1,8 @@
 // Copyright 2016 Wladimir J. van der Laan
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#ifndef UNIVALUE_UTFFILTER_H
-#define UNIVALUE_UTFFILTER_H
+#ifndef BITCOIN_UNIVALUE_LIB_UNIVALUE_UTFFILTER_H
+#define BITCOIN_UNIVALUE_LIB_UNIVALUE_UTFFILTER_H
 
 #include <string>
 
@@ -111,4 +111,4 @@ private:
     }
 };
 
-#endif
+#endif // BITCOIN_UNIVALUE_LIB_UNIVALUE_UTFFILTER_H

--- a/src/utilmemory.h
+++ b/src/utilmemory.h
@@ -16,4 +16,4 @@ std::unique_ptr<T> MakeUnique(Args&&... args)
     return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
-#endif
+#endif // BITCOIN_UTILMEMORY_H

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -28,4 +28,4 @@ bool EnsureWalletIsAvailable(CWallet *, bool avoidException);
 
 UniValue getaddressinfo(const JSONRPCRequest& request);
 UniValue signrawtransactionwithwallet(const JSONRPCRequest& request);
-#endif //BITCOIN_WALLET_RPCWALLET_H
+#endif // BITCOIN_WALLET_RPCWALLET_H

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -21,4 +21,4 @@ void SetfLargeWorkInvalidChainFound(bool flag);
  */
 std::string GetWarnings(const std::string& strFor);
 
-#endif //  BITCOIN_WARNINGS_H
+#endif // BITCOIN_WARNINGS_H

--- a/src/zmq/zmqrpc.h
+++ b/src/zmq/zmqrpc.h
@@ -9,4 +9,4 @@ class CRPCTable;
 
 void RegisterZMQRPCCommands(CRPCTable& t);
 
-#endif // BITCOIN_ZMQ_ZMRRPC_H
+#endif // BITCOIN_ZMQ_ZMQRPC_H


### PR DESCRIPTION
## Issue being fixed or feature implemented

- Standardizes include guards across the codebase to follow a consistent naming convention (`BITCOIN_<FILENAME>_H`) and proper C++ comment style (`// <guard>`). This improves code consistency and maintainability.
- No specific issue linked; this is a code quality/maintenance improvement.

## What was done?

- Converted non-standard include guards to `BITCOIN_<FILENAME>_H` format (e.g., `__ctpl_thread_pool_H__` → `BITCOIN_CTPL_H`)
- Added missing guards with proper comment endings (e.g., `#endif` → `#endif // BITCOIN_<NAME>_H`)
- Standardized comment spacing (e.g., `#endif //  BITCOIN_...` → `#endif // BITCOIN_...`)
- Also includes related lint tooling changes: removed legacy shell scripts and added Python lint equivalents

## How Has This Been Tested?

- Ran `test/lint/lint-include-guards.py` locally to verify all headers pass validation
- Code compiles successfully (no functional changes - style fix only)

## Breaking Changes

None - this is a code style change only.

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized header guard comment formatting and spacing consistency across all header files in the codebase.
  * Updated include guard macro naming to follow unified project-wide conventions and standards.
  * Normalized preprocessor directive closing comments to use consistent C++-style formatting throughout.
  * Corrected whitespace and comment style inconsistencies across multiple header files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->