### PR TITLE
fix(qt): fix keyboard input on Linux by setting XKB environment

### DIFF
--- a/src/qt/gobyte.cpp
+++ b/src/qt/gobyte.cpp
@@ -46,7 +46,9 @@
 
 #include <QApplication>
 #include <QDebug>
+#include <QProcessEnvironment>
 #include <QLibraryInfo>
+#include <QtGlobal>
 #include <QLocale>
 #include <QMessageBox>
 #include <QProcess>
@@ -591,6 +593,33 @@ int main(int argc, char* argv[])
 #endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
+#endif
+
+    // Set XKB environment variables for compatibility with modern Linux/Wayland.
+    // This fixes keyboard input issues on Ubuntu 24.04 and similar systems.
+    // Only set if not already defined by the user.
+#if defined(Q_OS_LINUX)
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+
+    // 1. Fix XKB Path: Resolves "failed to add default include path auto"
+    // Standard on Ubuntu 18.04 through 26.04.
+    if (!env.contains("QT_XKB_CONFIG_ROOT")) {
+        qputenv("QT_XKB_CONFIG_ROOT", "/usr/share/X11/xkb");
+    }
+
+    // 2. Force XCB: Ensures stability for legacy Qt event loops on Wayland-default distros.
+    if (!env.contains("QT_QPA_PLATFORM")) {
+        qputenv("QT_QPA_PLATFORM", "xcb");
+    }
+
+    // 3. Targeted IBus Fix: Only disable IM_MODULE if IBus is detected active.
+    // This prevents the 'dead-input' bug on Ubuntu 24.04/GNOME 46 while
+    // preserving IME support for users on Fcitx or other frameworks.
+    if (!env.contains("QT_IM_MODULE")) {
+        if (env.contains("IBUS_DAEMON_PID") || env.contains("IBUS_ADDRESS")) {
+            qputenv("QT_IM_MODULE", "none");
+        }
+    }
 #endif
 
     BitcoinApplication app(*node, argc, argv);


### PR DESCRIPTION
# Fix keyboard input and XKB context errors on modern Linux (Ubuntu 24.04+)

This change addresses critical keyboard input failures on modern Linux distributions, specifically Ubuntu 24.04 and newer. It programmatically sets default XKB environment variables (`QT_XKB_CONFIG_ROOT`, `QT_IM_MODULE`, `QT_QPA_PLATFORM`) within the application lifecycle. These are applied only if they are not already defined by the user, ensuring out-of-the-box compatibility without overriding custom configurations.

This PR addresses the Issue https://github.com/gobytecoin/gobyte/issues/60 so it should be backported to v0.16.2x branch.

## Issue being fixed or feature implemented

On Ubuntu 24.04 (and other systems using GNOME 46+ or Wayland), the GoByte-Qt GUI fails to initialize the keyboard context. This results in "dead" input fields where the user can click buttons with a mouse but cannot type addresses, amounts, or console commands.

**The root causes fixed by this PR are:**

1. **XKB Path Mismatch:** Modern distros changed how X11 keyboard configs are located; legacy Qt 5/6 versions fail to "auto-detect" these paths, leading to the error: `failed to add default include path auto`.

2. **IBus Conflict:** Modern GNOME input modules conflict with older Qt event loops.

3. **Display Protocol Stability:** Forcing the `xcb` (X11) platform ensures the wallet runs reliably via XWayland on Wayland-default systems.

## What was done?

* Modified `src/qt/gobyte.cpp` to include `<QProcessEnvironment>` and `<QtGlobal>`.
* Added a logic block at the beginning of `main()` to detect the Linux environment.
* Implemented `QProcessEnvironment::systemEnvironment().contains()` checks to ensure we only provide fallback values if the user hasn't set their own.
* Set `QT_XKB_CONFIG_ROOT` to `/usr/share/X11/xkb` (the standard path for Ubuntu 18.04 through 26.04).
* Set `QT_IM_MODULE=none` to bypass IBus focus issues.
* Set `QT_QPA_PLATFORM=xcb` to ensure consistent keyboard focus handling.

## How Has This Been Tested?

Environment: - OS: Ubuntu 24.04.4 LTS (Noble Numbat)
* **Desktop:** GNOME 46.0
* **Display Protocol:** X11 and Wayland
* **Compiler:** GCC (Self-compiled from source)

**Test Steps:**
1. Clean build of the source code on Ubuntu 24.04.
2. Launch `gobyte-qt` via terminal and via `.desktop` file.
3. Verified that the terminal no longer outputs `Qt: Failed to create XKB context!`.
4. Verified that keyboard input is fully functional in the "Receive" address labels and the "Debug Console".
5. Verified that setting a custom `QT_QPA_PLATFORM` in the terminal prior to launch still takes precedence over the fallback.

## Breaking Changes

None. The use of `!env.contains` ensures that existing setups on older Linux distributions or custom power-user configurations are not overridden.

## Checklist:

_Go over all the following points, and put an `x` in all the boxes that apply._

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Linux startup to better detect and configure the graphical/display backend and input method integration, reducing issues with keyboard layouts, input methods, and display compatibility on affected systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->